### PR TITLE
Add image caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ docker-compose.yaml
 template.html
 config.yaml
 /static
+/cache

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -4,3 +4,4 @@ date_format: "02.01.2006" # Go date format: https://gosamples.dev/date-time-form
 max_cache: "87600h"       # Duration of the cache header
 line_break_characters:    # Characters or substrings converted to line breaks
     - ": "
+cache_dir: "cache"        # Image cache directory (relative to project path)

--- a/docker-compose.yaml.example
+++ b/docker-compose.yaml.example
@@ -9,3 +9,4 @@ services:
       - ./config.yaml:/app/config.yaml
       - ./template.html:/app/template.html
       - ./static:/app/static
+      - ./cache:/app/cache

--- a/internal/pkg/cache/cache.go
+++ b/internal/pkg/cache/cache.go
@@ -1,0 +1,67 @@
+package cache
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/saaste/opengraph-image-creator/internal/pkg/config"
+)
+
+type CachedImage struct {
+	Data    []byte
+	ModTime time.Time
+}
+
+func TryGetImageFromCache(appConf *config.AppConfig, key string) (*CachedImage, error) {
+	err := createCacheDirIfNotExist(appConf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the cache directory: %w", err)
+	}
+
+	imageName := fmt.Sprintf("%s.png", key)
+	filePath := fmt.Sprintf("%s/%s", appConf.CacheDir, imageName)
+
+	stats, err := os.Stat(filePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			log.Printf("Image %s not found in cache\n", imageName)
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed checking if image exists: %w", err)
+	}
+
+	imageData, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read the image file: %w", err)
+	}
+
+	log.Printf("Image %s found in cache\n", imageName)
+	return &CachedImage{
+		Data:    imageData,
+		ModTime: stats.ModTime(),
+	}, nil
+}
+
+func SaveImageToCache(appConf *config.AppConfig, key string, imageData []byte) error {
+	err := createCacheDirIfNotExist(appConf)
+	if err != nil {
+		return fmt.Errorf("failed to create the cache directory: %w", err)
+	}
+
+	filePath := fmt.Sprintf("%s/%s.png", appConf.CacheDir, key)
+	return os.WriteFile(filePath, imageData, 0644)
+}
+
+func createCacheDirIfNotExist(appConf *config.AppConfig) error {
+	if _, err := os.Stat(appConf.CacheDir); os.IsNotExist(err) {
+		log.Println("Cache dir does not exist. Creating...")
+		if err = os.MkdirAll(appConf.CacheDir, os.ModePerm); err != nil {
+			return err
+		}
+		log.Println("Cache dir created.")
+	}
+	return nil
+}

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -14,6 +14,7 @@ type AppConfig struct {
 	DateFormat     string        `yaml:"date_format"`
 	LineBreakChars []string      `yaml:"line_break_characters"`
 	MaxCache       time.Duration `yaml:"max_cache"`
+	CacheDir       string        `yaml:"cache_dir"`
 }
 
 func Load() (*AppConfig, error) {


### PR DESCRIPTION
- Add a new setting to config: `cache_dir`
- Store created images to file cache
- Serve images from cache when they exist