### PR TITLE
Fix invalid JPEG data bug

### DIFF
--- a/cmd/server/handlers.go
+++ b/cmd/server/handlers.go
@@ -162,14 +162,14 @@ func handleOpenGraphImageRequest(w http.ResponseWriter, r *http.Request, imageTy
 		return
 	}
 
-	err = cache.SaveImageToCache(appConfig, eTag, imageBytes, imageType)
+	cachedImage, err = cache.SaveImageToCache(appConfig, eTag, imageBytes, imageType)
 	if err != nil {
 		log.Printf("Failed to save image to cache: %v\n", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 
-	http.ServeContent(w, r, outputFileName, time.Now(), bytes.NewReader(imageBytes))
+	http.ServeContent(w, r, outputFileName, time.Now(), bytes.NewReader(cachedImage.Data))
 }
 
 func handleStaticFiles(r chi.Router, path string, root http.FileSystem) {


### PR DESCRIPTION
When a JPEG image is not found in the cache, the handler returns all the correct headers but returns data from the screenshot (PNG) instead of JPEG image.

This PR fixes the issue by returning the cached image, which contains the correct data.